### PR TITLE
fix: stop baking GH_TOKEN into config-svc-be image (PAT leak)

### DIFF
--- a/.github/workflows/dockerhub-image-build-rc.yml
+++ b/.github/workflows/dockerhub-image-build-rc.yml
@@ -59,7 +59,8 @@ jobs:
           push: true
           tags: ${{ steps.meta_be.outputs.tags }}
           labels: ${{ steps.meta_be.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN_LIB }}
 
       - name: Generate artifact attestation for config-svc-be
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/dockerhub-image-build.yml
+++ b/.github/workflows/dockerhub-image-build.yml
@@ -57,7 +57,8 @@ jobs:
           push: true
           tags: ${{ steps.meta_be.outputs.tags }}
           labels: ${{ steps.meta_be.outputs.labels }}
-          build-args: GH_TOKEN=${{ secrets.GH_TOKEN }}
+          secrets: |
+            GH_TOKEN=${{ secrets.GH_TOKEN }}
 
       - name: Generate artifact attestation for config-svc-be
         uses: actions/attest-build-provenance@v1

--- a/packages/config-svc-be/Dockerfile.be
+++ b/packages/config-svc-be/Dockerfile.be
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # Use Node.js 20 as the base image
 FROM node:20
 
@@ -7,10 +8,11 @@ WORKDIR /app
 # Copy package.json and package-lock.json
 COPY packages/config-svc-be/package*.json ./
 
-# Create .npmrc file dynamically with GH_TOKEN
-ARG GH_TOKEN
+# Create .npmrc that reads the token from the environment at install time.
+# The token is supplied via a BuildKit secret mount and is never written into
+# any image layer, so it cannot leak in the published image.
 RUN echo "@tazama-lf:registry=https://npm.pkg.github.com" > .npmrc \
-    && echo "//npm.pkg.github.com/:_authToken=${GH_TOKEN}" >> .npmrc
+    && echo "//npm.pkg.github.com/:_authToken=\${GH_TOKEN}" >> .npmrc
 
 # Install nvm and set Node.js version
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash \
@@ -20,13 +22,13 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | b
     && nvm use 20
 
 # Install dependencies
-RUN npm install
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install
 
 # Install specific auth-lib package
-RUN npm install @tazama-lf/auth-lib
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install @tazama-lf/auth-lib
 
 # Install audit and logging library
-RUN npm install @tazama-lf/frms-coe-lib
+RUN --mount=type=secret,id=GH_TOKEN,env=GH_TOKEN npm install @tazama-lf/frms-coe-lib
 
 # Copy the rest of the backend code
 COPY packages/config-svc-be ./


### PR DESCRIPTION
## Problem

`packages/config-svc-be/Dockerfile.be` received the `@tazama-lf` registry PAT via a `build-args: GH_TOKEN=...` argument, wrote it into `.npmrc`, and never deleted it. The credential was baked into a published image layer, so anyone pulling `tazamaorg/config-svc-be` could extract the token. This was the source of one of the leaked `ghp_` tokens flagged on public DockerHub.

## Fix

- `Dockerfile.be`: add `# syntax=docker/dockerfile:1`, drop `ARG GH_TOKEN`, and mount the token via BuildKit `--mount=type=secret,id=GH_TOKEN,env=GH_TOKEN` on every `npm install`. The `.npmrc` now references `${GH_TOKEN}` from the environment at install time only - nothing is persisted.
- `dockerhub-image-build.yml` / `dockerhub-image-build-rc.yml`: pass the token through `secrets:` instead of `build-args:` for the be image build.

FE images are unaffected - they never needed a token.

## Notes

- The previously leaked tokens have already been revoked and the bad image tags deleted.
- This brings config-svc-be in line with the secret-mount pattern already used by tazama-demo, lumberjack and event-sidecar.
